### PR TITLE
encodes : and | when using them in url

### DIFF
--- a/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/elasticsearch/hadoop/rest/SearchRequestBuilder.java
@@ -187,12 +187,12 @@ public class SearchRequestBuilder {
 
         StringBuilder pref = new StringBuilder();
         if (StringUtils.hasText(shard)) {
-            pref.append("_shards:");
+            pref.append("_shards%3A");
             pref.append(shard);
         }
         if (local) {
             if (pref.length() > 0) {
-                pref.append("|");
+                pref.append("%7C");
             }
             pref.append("_local");
         }


### PR DESCRIPTION
Encodes : and | when building search url parameters.  Fixes issue #868
